### PR TITLE
Add dependencies explicitly to requirements file, and pin all versions.

### DIFF
--- a/requirements/mozwebqa.txt
+++ b/requirements/mozwebqa.txt
@@ -1,8 +1,14 @@
 # This pulls in all the libraries needed to run Selenium tests
 # on the Mozilla CaseConductor project
 
-selenium
-pytest
-pytest-xdist
-pytest-mozwebqa
-unittestzero
+selenium==2.6.0
+pytest==2.1.1
+pytest-mozwebqa==0.2
+pytest-xdist==1.6
+UnittestZero==0.1.6
+
+# dependencies
+PyYAML==3.10
+execnet==1.0.9
+py==1.4.5
+rdflib==3.1.0


### PR DESCRIPTION
Using un-pinned requirements in a requirements file is dangerous, as you never know when a new version of something might be released to PyPI that could cause (perhaps subtle) breakage, and it can be very confusing and time-consuming to sort out why the person who set up their environment yesterday is getting errors that the person who set it up a month ago can't duplicate.

Pinning exact versions of all dependencies (including dependencies of dependencies) allows you to upgrade to new versions in a controlled way, on your schedule, and with an opportunity to verify that nothing broke.
