### PR TITLE
Git-ignore selenium server jar so it can be kept with tests repo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 *.komodoproject
 *.idea
+selenium-server-standalone-*.jar


### PR DESCRIPTION
This just adds a pattern to the .gitignore file that will match selenium server jars, which allows the jar file to be kept with the test repo (so you don't lose track of where you put it) without actually being committed.
