### PR TITLE
Test that user can filter product by name

### DIFF
--- a/create_product_page.py
+++ b/create_product_page.py
@@ -48,7 +48,7 @@ class CaseConductorCreateProductPage(CaseConductorBasePage):
     _profile_locator = "id=id_profile"
     _description_locator = "id=id_description"
     _submit_locator = "css=div.form-actions>button"
-    _product_locator = u"css=#manageproducts article.item .title:contains(%(product_name)s)"
+    _product_locator = u'css=#manageproducts article.item .title:contains(%(product_name)s)'
 
     def go_to_create_product_page(self, login=False, user="default"):
         self.selenium.open('/manage/product/add/')
@@ -63,12 +63,12 @@ class CaseConductorCreateProductPage(CaseConductorBasePage):
     def create_product(self, name="Test Product", desc="This is a test product", profile="Browser Testing Environments"):
         dt_string = datetime.utcnow().isoformat()
         product = {}
-        product["name"] = name + " " + dt_string
-        product["desc"] = desc + " created on " + dt_string
-        product["locator"] = self._product_locator % {"product_name": product["name"]}
+        product['name'] = name + ' ' + dt_string
+        product['desc'] = desc + ' created on ' + dt_string
+        product['locator'] = self._product_locator % {'product_name': product['name']}
 
-        self.type(self._name_locator, product["name"])
-        self.type(self._description_locator, product["desc"])
+        self.type(self._name_locator, product['name'])
+        self.type(self._description_locator, product['desc'])
         self.select(self._profile_locator, profile)
         self.click(self._submit_locator, wait_flag=True)
 

--- a/manage_products_page.py
+++ b/manage_products_page.py
@@ -43,10 +43,10 @@ class CaseConductorManageProductsPage(CaseConductorBasePage):
 
     _page_title = "Mozilla Case Conductor"
     _delete_product_locator = u"css=#manageproducts article.item .title:contains(%(product_name)s) ~ .controls button[title='delete']"
-    _input_locator = "id=text-filter"
-    _update_list_locator = "css=#filter .visual .content .form-actions button"
-    _filter_suggestion_locator = u"css=#filter .textual .suggest a:contains(%(filter_name)s)"
-    _filter_locator = u"css=#filter .visual .filter-group input[value='%(filter_name)s']"
+    _input_locator = 'id=text-filter'
+    _update_list_locator = 'css=#filter .visual .content .form-actions button'
+    _filter_suggestion_locator = u'css=#filter .textual .suggest a:contains(%(filter_name)s)'
+    _filter_locator = u'css=#filter .visual .filter-group input[value="%(filter_name)s"]'
 
     def go_to_manage_products_page(self, login=False, user="default"):
         self.selenium.open('/manage/products/')
@@ -65,7 +65,7 @@ class CaseConductorManageProductsPage(CaseConductorBasePage):
         self.wait_for_element_not_visible(_delete_locator)
 
     def filter_products_by_name(self, name):
-        _filter_suggestion_locator = self._filter_suggestion_locator % {"filter_name": name}
+        _filter_suggestion_locator = self._filter_suggestion_locator % {'filter_name': name}
         _name_without_last_character = name[:-1]
         _name_last_character = name[-1]
 
@@ -79,7 +79,7 @@ class CaseConductorManageProductsPage(CaseConductorBasePage):
         self.click(self._update_list_locator, wait_flag=True)
 
     def remove_name_filter(self, name):
-        _filter_locator = self._filter_locator % {"filter_name": name}
+        _filter_locator = self._filter_locator % {'filter_name': name}
 
         self.click(_filter_locator)
         self.wait_for_element_visible(self._update_list_locator)

--- a/test_manage_products_page.py
+++ b/test_manage_products_page.py
@@ -51,13 +51,13 @@ class TestManageProductsPage:
 
         product = create_product_pg.create_product()
 
-        manage_products_pg.filter_products_by_name(name=product["name"])
+        manage_products_pg.filter_products_by_name(name=product['name'])
 
-        Assert.true(manage_products_pg.is_element_present(product["locator"]))
+        Assert.true(manage_products_pg.is_element_present(product['locator']))
 
-        manage_products_pg.delete_product(name=product["name"])
+        manage_products_pg.delete_product(name=product['name'])
 
-        Assert.false(manage_products_pg.is_element_present(product["locator"]))
+        Assert.false(manage_products_pg.is_element_present(product['locator']))
 
     def test_that_user_can_filter_product_by_name(self, mozwebqa):
         manage_products_pg = CaseConductorManageProductsPage(mozwebqa)
@@ -67,13 +67,13 @@ class TestManageProductsPage:
 
         product = create_product_pg.create_product()
 
-        manage_products_pg.filter_products_by_name(name="Another Product")
+        manage_products_pg.filter_products_by_name(name='Another Product')
 
-        Assert.false(manage_products_pg.is_element_present(product["locator"]))
+        Assert.false(manage_products_pg.is_element_present(product['locator']))
 
-        manage_products_pg.remove_name_filter(name="Another Product")
-        manage_products_pg.filter_products_by_name(name=product["name"])
+        manage_products_pg.remove_name_filter(name='Another Product')
+        manage_products_pg.filter_products_by_name(name=product['name'])
 
-        Assert.true(manage_products_pg.is_element_present(product["locator"]))
+        Assert.true(manage_products_pg.is_element_present(product['locator']))
 
-        manage_products_pg.delete_product(name=product["name"])
+        manage_products_pg.delete_product(name=product['name'])


### PR DESCRIPTION
- Added test that user can filter products by name
- Added name-filtering to existing test-that-user-can-create-and-delete-product (in case product would not otherwise be visible on first page)
- Added _create_product helper function to avoid code duplication
