### PR TITLE
Update logic for is_the_current_page to address titles on dev

### DIFF
--- a/pages/create_case_page.py
+++ b/pages/create_case_page.py
@@ -14,7 +14,7 @@ from pages.base_page import MozTrapBasePage
 
 class MozTrapCreateCasePage(MozTrapBasePage):
 
-    _page_title = 'MozTrap'
+    _page_title = 'Create Case'
 
     _name_locator = (By.ID, 'id_name')
     _product_select_locator = (By.ID, 'id_product')

--- a/pages/create_product_page.py
+++ b/pages/create_product_page.py
@@ -14,7 +14,7 @@ from pages.base_page import MozTrapBasePage
 
 class MozTrapCreateProductPage(MozTrapBasePage):
 
-    _page_title = 'MozTrap'
+    _page_title = 'Create Product'
 
     _name_locator = (By.ID, 'id_name')
     _version_locator = (By.ID, 'id_version')

--- a/pages/create_profile_page.py
+++ b/pages/create_profile_page.py
@@ -15,7 +15,7 @@ from base_page import MozTrapBasePage
 
 class MozTrapCreateProfilePage(MozTrapBasePage):
 
-    _page_title = 'MozTrap'
+    _page_title = 'Create Profile'
 
     _profile_name_locator = (By.ID, 'id_name')
     _select_category_locator = (By.CSS_SELECTOR, '#profile-add-form .itemlist .bulkselectitem[data-title="%(category_name)s"] .listitem .itembody .element[data-title="%(element_name)s"] label')

--- a/pages/create_run_page.py
+++ b/pages/create_run_page.py
@@ -14,7 +14,7 @@ from pages.base_page import MozTrapBasePage
 
 class MozTrapCreateRunPage(MozTrapBasePage):
 
-    _page_title = 'MozTrap'
+    _page_title = 'Create Run'
 
     _name_locator = (By.ID, 'id_name')
     _product_version_select_locator = (By.ID, 'id_productversion')
@@ -43,7 +43,6 @@ class MozTrapCreateRunPage(MozTrapBasePage):
         run['homepage_locator'] = (self._run_homepage_locator[0], self._run_homepage_locator[1] % {'run_name': run['name']})
         run['run_tests_locator'] = self._run_tests_button_locator
 
-
         name_field = self.selenium.find_element(*self._name_locator)
         name_field.send_keys(run['name'])
 
@@ -55,7 +54,6 @@ class MozTrapCreateRunPage(MozTrapBasePage):
         else:
             if series_run:
                 series_element.click()
-
 
         product_version_select = Select(self.selenium.find_element(*self._product_version_select_locator))
         product_version_select.select_by_visible_text(product_version)

--- a/pages/create_suite_page.py
+++ b/pages/create_suite_page.py
@@ -14,7 +14,7 @@ from pages.base_page import MozTrapBasePage
 
 class MozTrapCreateSuitePage(MozTrapBasePage):
 
-    _page_title = 'MozTrap'
+    _page_title = 'Create Suite'
 
     _name_locator = (By.ID, 'id_name')
     _product_select_locator = (By.ID, 'id_product')

--- a/pages/create_version_page.py
+++ b/pages/create_version_page.py
@@ -14,7 +14,7 @@ from pages.base_page import MozTrapBasePage
 
 class MozTrapCreateVersionPage(MozTrapBasePage):
 
-    _page_title = 'MozTrap'
+    _page_title = 'Create Version'
 
     _version_name_locator = (By.ID, 'id_version')
     _product_select_locator = (By.ID, 'id_product')

--- a/pages/home_page.py
+++ b/pages/home_page.py
@@ -12,7 +12,7 @@ from pages.base_page import MozTrapBasePage
 
 class MozTrapHomePage(MozTrapBasePage):
 
-    _page_title = 'MozTrap'
+    _page_title = 'Run Tests'
 
     _select_locator = (By.CSS_SELECTOR, '.runsdrill .runsfinder .carousel .colcontent .title[title="%(item_name)s"]')
     _env_select_locator = (By.CSS_SELECTOR, '#runtests-environment-form .formfield[data-title="%(env_category)s"] select')

--- a/pages/login_page.py
+++ b/pages/login_page.py
@@ -12,7 +12,7 @@ from pages.base_page import MozTrapBasePage
 
 class MozTrapLoginPage(MozTrapBasePage):
 
-    _page_title = 'Login | MozTrap'
+    _page_title = 'Login'
 
     _username_locator = (By.ID, 'id_username')
     _password_locator = (By.ID, 'id_password')

--- a/pages/manage_cases_page.py
+++ b/pages/manage_cases_page.py
@@ -11,7 +11,7 @@ from pages.base_page import MozTrapBasePage
 
 class MozTrapManageCasesPage(MozTrapBasePage):
 
-    _page_title = 'MozTrap'
+    _page_title = 'Manage-Cases'
 
     _delete_case_locator = (By.CSS_SELECTOR, '#managecases .itemlist .listitem[data-title="%(case_name)s"] .action-delete')
     _case_status_locator = (By.CSS_SELECTOR, '#managecases .itemlist .listitem[data-title="%(case_name)s"] .status-action')

--- a/pages/manage_products_page.py
+++ b/pages/manage_products_page.py
@@ -13,7 +13,7 @@ from pages.base_page import MozTrapBasePage
 
 class MozTrapManageProductsPage(MozTrapBasePage):
 
-    _page_title = 'MozTrap'
+    _page_title = 'Manage-Products'
     _delete_product_locator = (By.CSS_SELECTOR, '#manageproducts .listitem .controls .action-delete[title="delete %(product_name)s"]')
     _filter_input_locator = (By.ID, 'text-filter')
     _filter_suggestion_locator = (By.CSS_SELECTOR, '#filter .textual .suggest .suggestion[data-type="name"][data-name="%(filter_name)s"]')

--- a/pages/manage_profiles_page.py
+++ b/pages/manage_profiles_page.py
@@ -11,7 +11,7 @@ from pages.base_page import MozTrapBasePage
 
 class MozTrapManageProfilesPage(MozTrapBasePage):
 
-    _page_title = 'MozTrap'
+    _page_title = 'Manage-Environments'
 
     _delete_profile_locator = (By.CSS_SELECTOR, '#manageprofiles .listitem .action-delete[title="delete %(profile_name)s"]')
     _filter_input_locator = (By.ID, 'text-filter')

--- a/pages/manage_runs_page.py
+++ b/pages/manage_runs_page.py
@@ -11,7 +11,7 @@ from pages.base_page import MozTrapBasePage
 
 class MozTrapManageRunsPage(MozTrapBasePage):
 
-    _page_title = 'MozTrap'
+    _page_title = 'Manage-Runs'
 
     _delete_run_locator = (By.CSS_SELECTOR, '#manageruns .itemlist .listitem[data-title="%(run_name)s"] .action-delete')
     _run_activate_locator = (By.CSS_SELECTOR, '#manageruns .itemlist .listitem[data-title="%(run_name)s"] .status-action.active')

--- a/pages/manage_suites_page.py
+++ b/pages/manage_suites_page.py
@@ -11,7 +11,7 @@ from pages.base_page import MozTrapBasePage
 
 class MozTrapManageSuitesPage(MozTrapBasePage):
 
-    _page_title = 'MozTrap'
+    _page_title = 'Manage-Suites'
 
     _delete_suite_locator = (By.CSS_SELECTOR, '#managesuites .itemlist .listitem[data-title="%(suite_name)s"] .action-delete')
     _suite_status_locator = (By.CSS_SELECTOR, '#managesuites .itemlist .listitem[data-title="%(suite_name)s"] .status-action')

--- a/pages/manage_versions_page.py
+++ b/pages/manage_versions_page.py
@@ -12,7 +12,7 @@ from pages.base_page import MozTrapBasePage
 
 class MozTrapManageVersionsPage(MozTrapBasePage):
 
-    _page_title = 'MozTrap'
+    _page_title = 'Manage-Versions'
 
     _version_manage_locator = (By.CSS_SELECTOR, '#manageproductversions .listitem .title[title="%(product_name)s %(version_name)s"]')
     _version_homepage_locator = (By.CSS_SELECTOR, '.runsdrill .runsfinder .productversions .colcontent .title[title="%(version_name)s"][data-product="%(product_name)s"])')

--- a/pages/page.py
+++ b/pages/page.py
@@ -8,7 +8,6 @@ from unittestzero import Assert
 
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import NoSuchElementException
-from selenium.common.exceptions import ElementNotVisibleException
 
 
 class Page(object):

--- a/pages/run_tests_page.py
+++ b/pages/run_tests_page.py
@@ -11,7 +11,7 @@ from pages.base_page import MozTrapBasePage
 
 class MozTrapRunTestsPage(MozTrapBasePage):
 
-    _page_title = 'MozTrap'
+    _page_title = 'Run Tests'
 
     _test_pass_locator = (By.CSS_SELECTOR, '#runtests .itemlist .listitem[data-title="%(case_name)s"] .itembody .action-pass')
     _test_is_passed_locator = (By.CSS_SELECTOR, '#runtests .itemlist .listitem.passed[data-title="%(case_name)s"]')


### PR DESCRIPTION
This addresses a number of failures on moztrap.dev. It looks like the page titles have changed to be labelled Moztrap-Dev, instead of just Moztrap. Simply changing the logic to use contains instead of equals should address this, without losing the safety of the check.

Note there are other failures on dev which still exist after applying this change, which I intend to address with another pull request.
