### PR TITLE
Add a shared user for api credentials

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -28,7 +28,7 @@ def product(request):
     mozwebqa = request.getfuncargvalue('mozwebqa')
     credentials = mozwebqa.credentials['default']
     request.product = MockProduct()
-    api = MoztrapAPI(credentials['username'], credentials['api_key'], mozwebqa.base_url)
+    api = MoztrapAPI(credentials['api_user'], credentials['api_key'], mozwebqa.base_url)
     api.create_product(request.product)
 
     # This acts like a tearDown, running after each test function
@@ -46,7 +46,7 @@ def element(request):
     mozwebqa = request.getfuncargvalue('mozwebqa')
     credentials = mozwebqa.credentials['default']
     request.element = MockElement()
-    api = MoztrapAPI(credentials['username'], credentials['api_key'], mozwebqa.base_url)
+    api = MoztrapAPI(credentials['api_user'], credentials['api_key'], mozwebqa.base_url)
     api.create_element(request.element)
 
     # The element and category cannot be deleted via the API at this point, likely because they

--- a/credentials.yaml
+++ b/credentials.yaml
@@ -32,8 +32,8 @@
 #   credentials['username']
 
 default:
-    username: <value> # Used if site uses username/password logins instead of BrowserID/Persona.
-    email: <value>    # Used if site uses BrowserID/Persona instead of username/password logins.
+    email: <value>
     password: <value>
     name: <value>
-    api_key: <value>
+    api_user: webqa_api_user
+    api_key: a0c050d8-84c8-49f5-963f-97eae922bc48

--- a/pages/login_page.py
+++ b/pages/login_page.py
@@ -30,15 +30,10 @@ class MozTrapLoginPage(MozTrapBasePage):
         if type(user) is str:
             user = self.testsetup.credentials[user]
 
-        if self.is_browserid_visible:
-            from browserid import BrowserID
-            self.selenium.find_element(*self._browserid_locator).click()
-            browser_id = BrowserID(self.selenium, timeout=self.timeout)
-            browser_id.sign_in(user['email'], user['password'])
-        else:
-            self.selenium.find_element(*self._username_locator).send_keys(user['username'])
-            self.selenium.find_element(*self._password_locator).send_keys(user['password'])
-            self.selenium.find_element(*self._submit_locator).click()
+        from browserid import BrowserID
+        self.selenium.find_element(*self._browserid_locator).click()
+        browser_id = BrowserID(self.selenium, timeout=self.timeout)
+        browser_id.sign_in(user['email'], user['password'])
 
         WebDriverWait(self.selenium, self.timeout).until(lambda s: self.header.is_user_logged_in)
 


### PR DESCRIPTION
Add an api_user key to the credentials file
Remove logic for non-Persona login
Remove unused username key from credentials file

This pull is to support having a shared user for accessing the api. All tests will need to use a user with an api key and this will simplify new contributors coming on. Also have removed the logic for logging into a non-Persona-enabled version of Moztrap as we do not test such an environment.

Note that there will be an associated webqa-credentials pull request to go with this.
