### PR TITLE
Fix test_editing_of_existing_suite_that_includes_cases by changing the way included cases are removed

### DIFF
--- a/pages/edit_suite_page.py
+++ b/pages/edit_suite_page.py
@@ -74,9 +74,11 @@ class MozTrapEditSuitePage(MozTrapBasePage):
 
     def remove_all_included_cases(self):
         self.wait_for_element_not_present(*self._loading_included_cases_locator)
+        remove_button = self.find_element(*self._remove_selected_cases_button_locator)
 
-        self.find_element(*self._included_cases_select_all_checkbox_locator).click()
-        self.find_element(*self._remove_selected_cases_button_locator).click()
+        for case in self.included_cases:
+            case.select()
+            remove_button.click()
 
     class TestCaseItem(PageRegion):
 


### PR DESCRIPTION
I added some debugging statements and was able to see that, for some reason, on dev and stage, the step to remove the existing cases from the suite was not working, so then the cases were not able to be added in in the correct order. I have high hopes that this will address the issue. I have run it several times on CI and all have passed.
