### PR TITLE
create tag with product value set

### DIFF
--- a/pages/create_run_page.py
+++ b/pages/create_run_page.py
@@ -10,6 +10,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.select import Select
 
 from pages.base_page import MozTrapBasePage
+from pages.regions.multiselect_widget import MultiselectWidget
 
 
 class MozTrapCreateRunPage(MozTrapBasePage):
@@ -21,8 +22,6 @@ class MozTrapCreateRunPage(MozTrapBasePage):
     _description_locator = (By.ID, 'id_description')
     _start_date_locator = (By.ID, 'id_start')
     _end_date_locator = (By.ID, 'id_end')
-    _suite_select_locator = (By.CSS_SELECTOR, '#run-add-form .multiunselected .itemlist article.selectitem[data-title="%(suite_name)s"] input.bulk-value')
-    _include_selected_suites_locator = (By.CSS_SELECTOR, '#run-add-form .multiselect .include-exclude .action-include')
     _submit_locator = (By.CSS_SELECTOR, '#run-add-form .form-actions > button')
     _run_manage_locator = (By.CSS_SELECTOR, '#manageruns .itemlist .listitem .title[title="%(run_name)s"]')
     _run_homepage_locator = (By.CSS_SELECTOR, '.runsdrill .runsfinder .runs .colcontent .title[title="%(run_name)s"]')
@@ -30,7 +29,7 @@ class MozTrapCreateRunPage(MozTrapBasePage):
     _series_run_locator = (By.ID, 'id_is_series')
 
     def go_to_create_run_page(self):
-        self.selenium.get(self.base_url + '/manage/run/add/')
+        self.get_relative_path('/manage/run/add/')
         self.is_the_current_page
 
     def create_run(self, name='Test Run', product_version='Test Product Test Version', desc='This is a test run', start_date='2011-01-01', end_date='2012-12-31', suite_list=None, series_run=False):
@@ -64,10 +63,7 @@ class MozTrapCreateRunPage(MozTrapBasePage):
         self.selenium.find_element(*self._end_date_locator).send_keys(end_date)
 
         if suite_list:
-            for suite in reversed(suite_list):
-                suite_input_element = self.selenium.find_element(By.XPATH, "//article[@data-title='%s']//label" % suite)
-                suite_input_element.click()
-                self.selenium.find_element(*self._include_selected_suites_locator).click()
+            self.multiselect_widget.include_items(suite_list)
         self.selenium.find_element(*self._submit_locator).click()
 
         return run
@@ -76,3 +72,7 @@ class MozTrapCreateRunPage(MozTrapBasePage):
     def product_version_value(self):
         product_version_select = self.find_element(*self._product_version_select_locator)
         return product_version_select.find_element(By.CSS_SELECTOR, 'option:checked').text
+
+    @property
+    def multiselect_widget(self):
+        return MultiselectWidget(self.testsetup)

--- a/pages/create_suite_page.py
+++ b/pages/create_suite_page.py
@@ -10,6 +10,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.select import Select
 
 from pages.base_page import MozTrapBasePage
+from pages.regions.multiselect_widget import MultiselectWidget
 
 
 class MozTrapCreateSuitePage(MozTrapBasePage):
@@ -21,8 +22,6 @@ class MozTrapCreateSuitePage(MozTrapBasePage):
     _description_locator = (By.ID, 'id_description')
     _status_select_locator = (By.ID, 'id_status')
     _submit_locator = (By.CSS_SELECTOR, '#suite-add-form .form-actions button[type="submit"]')
-    _case_select_locator = (By.CSS_SELECTOR, '#suite-add-form .multiunselected .itemlist .selectitem[data-title="%(case_name)s"] input.bulk-value')
-    _include_selected_cases_locator = (By.CSS_SELECTOR, '#suite-add-form .multiselect .include-exclude .action-include')
     _suite_locator = (By.CSS_SELECTOR, '#managesuites .itemlist .listitem .title[title="%(suite_name)s"]')
 
     def go_to_create_suite_page(self):
@@ -46,10 +45,7 @@ class MozTrapCreateSuitePage(MozTrapBasePage):
         status_select.select_by_visible_text(status)
 
         if case_list:
-            for case in reversed(case_list):
-                case_element = self.selenium.find_element(By.XPATH, "//article[@data-title='%s']/div/label" % case)
-                case_element.click()
-                self.selenium.find_element(*self._include_selected_cases_locator).click()
+            self.multiselect_widget.include_items(case_list)
         self.selenium.find_element(*self._submit_locator).click()
 
         return suite
@@ -58,3 +54,7 @@ class MozTrapCreateSuitePage(MozTrapBasePage):
     def product_name_value(self):
         product_select = self.find_element(*self._product_select_locator)
         return product_select.find_element(By.CSS_SELECTOR, 'option:checked').text
+
+    @property
+    def multiselect_widget(self):
+        return MultiselectWidget(self.testsetup)

--- a/pages/create_tag_page.py
+++ b/pages/create_tag_page.py
@@ -5,22 +5,47 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.select import Select
 
 from pages.base_page import MozTrapBasePage
+from pages.regions.multiselect_widget import MultiselectWidget
 
 
 class MozTrapCreateTagPage(MozTrapBasePage):
 
     _name_input_locator = (By.ID, 'id_name')
+    _product_select_locator = (By.ID, 'id_product')
     _description_input_locator = (By.ID, 'id_description')
     _submit_button_locator = (By.CSS_SELECTOR, '.form-actions > button[type="submit"]')
-    _multiselect_widget_locator = (By.CSS_SELECTOR, '.multiselect')
 
-    def create_tag(self, tag_mock):
+    def create_tag(self, tag_mock, save_tag=True):
         self.find_element(*self._name_input_locator).send_keys(tag_mock.name)
+
+        if tag_mock.product:
+            product_select = Select(self.selenium.find_element(*self._product_select_locator))
+            product_select.select_by_visible_text(tag_mock.product)
+
         self.find_element(*self._description_input_locator).send_keys(tag_mock.description)
+
+        if save_tag:
+            self.save_tag()
+
+    def save_tag(self):
         self.find_element(*self._submit_button_locator).click()
 
     @property
+    def multiselect_widget(self):
+        return MultiselectWidget(self.testsetup)
+
+    @property
     def is_multiselect_widget_visible(self):
-        return self.is_element_visible(*self._multiselect_widget_locator)
+        return self.multiselect_widget.is_visible
+
+    @property
+    def available_caseversions(self):
+        return self.multiselect_widget.available_items
+
+    def include_caseversions_to_tag(self, caseversions_list, save_tag=True):
+        self.multiselect_widget.include_items(caseversions_list)
+        if save_tag:
+            self.save_tag()

--- a/pages/edit_run_page.py
+++ b/pages/edit_run_page.py
@@ -9,6 +9,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.select import Select
 
 from pages.base_page import MozTrapBasePage
+from pages.regions.multiselect_widget import MultiselectWidget
 
 
 class MozTrapEditRunPage(MozTrapBasePage):
@@ -21,11 +22,7 @@ class MozTrapEditRunPage(MozTrapBasePage):
     _start_date_locator = (By.ID, 'id_start')
     _end_date_locator = (By.ID, 'id_end')
     _series_run_locator = (By.ID, 'id_is_series')
-    _include_selected_suites_locator = (By.CSS_SELECTOR, '.multiselect .include-exclude .action-include')
-    _sort_included_suites_by_name_locator = (By.CSS_SELECTOR, '.multiselected .byname .sortlink')
-    _loading_included_suites_locator = (By.CSS_SELECTOR, '.multiselected .select[data-name="suites"] .overlay')
     _submit_locator = (By.CSS_SELECTOR, '#run-edit-form .form-actions > button')
-    _multiselect_widget_locator = (By.CSS_SELECTOR, '#run-edit-form .multiselect')
     _readonly_included_suite_locator = (By.CSS_SELECTOR, '.suites-field .value > li')
 
     def edit_run(self, run, name=None, product_version=None, desc=None,
@@ -60,10 +57,7 @@ class MozTrapEditRunPage(MozTrapBasePage):
             run['series'] = series_run
 
         if reorder_suites:
-            sorter = self.find_element(*self._sort_included_suites_by_name_locator)
-            self.wait_for_element_not_present(*self._loading_included_suites_locator)
-            sorter.click()
-            sorter.click()
+            self.multiselect_widget.reorder_included_items()
 
         self.save_run()
 
@@ -73,9 +67,13 @@ class MozTrapEditRunPage(MozTrapBasePage):
         self.find_element(*self._submit_locator).click()
 
     @property
-    def is_multiselect_widget_present(self):
-        return self.is_element_present(*self._multiselect_widget_locator)
-
-    @property
     def readonly_included_suites(self):
         return [item.text for item in self.find_elements(*self._readonly_included_suite_locator)]
+
+    @property
+    def multiselect_widget(self):
+        return MultiselectWidget(self.testsetup)
+
+    @property
+    def is_multiselect_widget_present(self):
+        return self.multiselect_widget.is_present

--- a/pages/regions/multiselect_widget.py
+++ b/pages/regions/multiselect_widget.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.page import Page, PageRegion
+
+
+class MultiselectWidget(Page):
+
+    _multiselect_widget_locator = (By.CSS_SELECTOR, '.multiselect')
+    _loading_available_items_locator = (By.CSS_SELECTOR, '.multiunselected .select .overlay')
+    _loading_included_items_locator = (By.CSS_SELECTOR, '.multiselected .select .overlay')
+    _available_item_locator = (By.CSS_SELECTOR, '.multiunselected .selectitem')
+    _included_item_locator = (By.CSS_SELECTOR, '.multiselected .selectitem')
+    _sort_included_items_by_name_locator = (By.CSS_SELECTOR, '.multiselected .byname .sortlink')
+    _include_item_button_locator = (By.CSS_SELECTOR, '.include-exclude .action-include')
+    _remove_item_button_locator = (By.CSS_SELECTOR, '.include-exclude .action-exclude')
+
+    @property
+    def available_items(self):
+        self.wait_for_element_not_present(*self._loading_available_items_locator)
+        return [Item(self.testsetup, web_element)
+                for web_element in self.find_elements(*self._available_item_locator)]
+
+    @property
+    def included_items(self):
+        self.wait_for_element_not_present(*self._loading_included_items_locator)
+        return [Item(self.testsetup, web_element)
+                for web_element in self.find_elements(*self._included_item_locator)]
+
+    def include_items(self, item_names_list):
+        #wait till available and included items are loaded
+        self.wait_for_element_not_present(*self._loading_available_items_locator)
+        self.wait_for_element_not_present(*self._loading_included_items_locator)
+        include_button = self.find_element(*self._include_item_button_locator)
+
+        items_to_add = [item
+                        for name in reversed(item_names_list)
+                        for item in self.available_items
+                        if name == item.name]
+
+        for item in items_to_add:
+            item.select()
+            include_button.click()
+
+    def reorder_included_items(self):
+        self.wait_for_element_not_present(*self._loading_included_items_locator)
+        sorter = self.find_element(*self._sort_included_items_by_name_locator)
+        # requires two clicks to reverse sorting
+        sorter.click()
+        sorter.click()
+
+    def remove_all_included_items(self):
+        self.wait_for_element_not_present(*self._loading_included_items_locator)
+        remove_button = self.find_element(*self._remove_item_button_locator)
+
+        for item in self.included_items:
+            item.select()
+
+        remove_button.click()
+
+    @property
+    def is_present(self):
+        return self.is_element_present(*self._multiselect_widget_locator)
+
+    @property
+    def is_visible(self):
+        return self.is_element_visible(*self._multiselect_widget_locator)
+
+
+class Item(PageRegion):
+
+    _select_item_locator = (By.CSS_SELECTOR, '.bulk-type')
+    _item_title_locator = (By.CSS_SELECTOR, '.title')
+
+    @property
+    def name(self):
+        return self.find_element(*self._item_title_locator).text
+
+    def select(self):
+        self.find_element(*self._select_item_locator).click()

--- a/pages/run_tests_page.py
+++ b/pages/run_tests_page.py
@@ -6,7 +6,7 @@
 
 from selenium.webdriver.common.by import By
 
-from pages.page import Page, PageRegion
+from pages.page import PageRegion
 from pages.base_page import MozTrapBasePage
 
 

--- a/tests/test_manage_suites_page.py
+++ b/tests/test_manage_suites_page.py
@@ -64,6 +64,7 @@ class TestManageSuitesPage(BaseTest):
             u'product version field should be editable')
 
         edit_suite_pg.include_cases_to_suite(case_list)
+
         manage_suites_pg.filter_form.filter_by(lookup='name', value=suite['name'])
         edit_suite_pg = manage_suites_pg.edit_suite(name=suite['name'])
 

--- a/tests/test_manage_tags_page.py
+++ b/tests/test_manage_tags_page.py
@@ -9,6 +9,7 @@ from unittestzero import Assert
 from mocks.mock_tag import MockTag
 from pages.base_test import BaseTest
 from pages.manage_tags_page import MozTrapManageTagsPage
+from pages.manage_cases_page import MozTrapManageCasesPage
 
 
 class TestManageTagsPage(BaseTest):
@@ -29,3 +30,48 @@ class TestManageTagsPage(BaseTest):
 
         Assert.true(tag['name'] in [t.name for t in displayed_tags],
                     'tag with "%s" name is not displayed on the page' % tag['name'])
+
+    def test_creating_a_tag_with_a_product_value_and_no_cases(self, mozwebqa_logged_in, product):
+        manage_tags_pg = MozTrapManageTagsPage(mozwebqa_logged_in)
+        manage_tags_pg.go_to_manage_tags_page()
+
+        create_tag_pg = manage_tags_pg.click_create_tag_button()
+        tag = MockTag(product=product['name'])
+        create_tag_pg.create_tag(tag, save_tag=False)
+
+        Assert.true(create_tag_pg.is_multiselect_widget_visible,
+                    'multiselect widget should be visible after product was selected')
+
+        create_tag_pg.save_tag()
+        manage_tags_pg.filter_form.filter_by(lookup='name', value=tag['name'])
+        displayed_tags = manage_tags_pg.tags()
+
+        Assert.true(tag['name'] in [t.name for t in displayed_tags],
+                    'tag with "%s" name is not displayed on the page' % tag['name'])
+
+    def test_creating_a_tag_with_a_product_value_and_cases(self, mozwebqa_logged_in, product):
+        # create some cases for product
+        cases = self.create_bulk_cases(mozwebqa_logged_in, product, use_API=True)
+        manage_tags_pg = MozTrapManageTagsPage(mozwebqa_logged_in)
+        manage_tags_pg.go_to_manage_tags_page()
+
+        create_tag_pg = manage_tags_pg.click_create_tag_button()
+        tag = MockTag(product=product['name'])
+        create_tag_pg.create_tag(tag, save_tag=False)
+
+        expected_case_names = [case.name for case in cases]
+        actual_case_names = [case.name for case in create_tag_pg.available_caseversions]
+
+        Assert.equal(sorted(expected_case_names), sorted(actual_case_names),
+                     'list of expected caseversions differs from actually displayed')
+
+        create_tag_pg.include_caseversions_to_tag(expected_case_names)
+
+        manage_cases_page = MozTrapManageCasesPage(mozwebqa_logged_in)
+        manage_cases_page.go_to_manage_cases_page()
+        manage_cases_page.filter_form.filter_by(lookup='tag', value=tag['name'])
+
+        displayed_case_names = [case.name for case in manage_cases_page.test_cases]
+
+        Assert.equal(sorted(expected_case_names), sorted(displayed_case_names),
+                     'list of test cases attached to a tag differs from expected')

--- a/tests/test_run_tests_page.py
+++ b/tests/test_run_tests_page.py
@@ -92,7 +92,7 @@ class TestRunTestsPage(BaseTest):
         manage_runs_pg.make_run_draft(first_run['name'])
         #go to edit run page and reorder suites by name (suite b, suite a)
         edit_run_pg = manage_runs_pg.go_to_edit_run_page(first_run['name'])
-        second_run = edit_run_pg.edit_run(first_run, reorder_suites=True)
+        edit_run_pg.edit_run(first_run, reorder_suites=True)
         #make run active again
         manage_runs_pg.filter_form.filter_by(lookup='name', value=first_run['name'])
         manage_runs_pg.activate_run(first_run['name'])


### PR DESCRIPTION
Addresses issue #125.

I made two tests that are similar but yet different. 
One test simply selects product and creates tag, another one not only selects product, but also includes caseversions. I can remove on of them or we can have them both. There is no mention in github issue what actually test should check.

While working on that issue, I recognized that multiselect widget is used across several PageObjects, so I moved all   related logic into separate PageRegion object and did some refactoring.

Another note: it appears that editing tag with some product set causes 500 server error in ajax request on edit tag page and thus no caseversions are loaded. I checked in bugzilla and saw one related bug, but maybe someone from the team needs to look at that issue more closely.
