### PR TITLE
Added maximize_window() for failing test

### DIFF
--- a/pages/login_page.py
+++ b/pages/login_page.py
@@ -22,6 +22,7 @@ class MozTrapLoginPage(MozTrapBasePage):
 
     def go_to_login_page(self):
         self.get_relative_path('/users/login/')
+        self.maximize_window()
         self.is_the_current_page
 
     def login(self, user='default'):

--- a/pages/manage_cases_page.py
+++ b/pages/manage_cases_page.py
@@ -26,7 +26,6 @@ class MozTrapManageCasesPage(MozTrapBasePage):
 
     def go_to_manage_cases_page(self):
         self.selenium.get(self.base_url + '/manage/cases/')
-        self.maximize_window()
         self.is_the_current_page
 
     def click_create_case_button(self):


### PR DESCRIPTION
Investigated the 1 fail on CI (http://qa-selenium.mv.mozilla.com:8080/view/MozTrap/job/moztrap.dev/48/testReport/tests.test_pinning_filters/TestPinningFilters/test_that_pinning_filters_on_product_and_version_and_suite_set_defaults_in_new_case/)
and the reason why this test fails is because the window needs to be maximized.
Tested this locally and got the same fail without it maximized. (http://qa-selenium.mv.mozilla.com:8080/view/MozTrap/job/moztrap.dev/48/HTML_Report/?)
