### PR TITLE
Use proper variable to compare to version select

### DIFF
--- a/pages/create_case_page.py
+++ b/pages/create_case_page.py
@@ -45,7 +45,7 @@ class MozTrapCreateCasePage(MozTrapBasePage):
         product_select.select_by_visible_text(product)
 
         version_select = Select(self.selenium.find_element(*self._version_select_locator))
-        version_select.select_by_visible_text(product)
+        version_select.select_by_visible_text(version)
 
         if suite:
             suite_select = Select(self.selenium.find_element(*self._suite_select_locator))


### PR DESCRIPTION
I'm not sure if the old code was a typo that luckily worked, or if it intended to use fuzzy logic, but in any case the fuzzy logic that used to work with `select_by_visible_text` no longer works, so the code needed to be changed. This new code makes more sense anyway.
