### PR TITLE
Fix test_that_user_can_select_run intermittent failure.

### DIFF
--- a/pages/create_version_page.py
+++ b/pages/create_version_page.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.select import Select
+from selenium.webdriver.support.ui import WebDriverWait
 
 from pages.base_page import MozTrapBasePage
 
@@ -21,6 +22,7 @@ class MozTrapCreateVersionPage(MozTrapBasePage):
     _submit_locator = (By.CSS_SELECTOR, '#productversion-add-form .form-actions > button')
     _version_manage_locator = (By.CSS_SELECTOR, '#manageproductversions .listitem .title[title="%(product_name)s %(version_name)s"]')
     _version_homepage_locator = (By.CSS_SELECTOR, '.runsdrill .runsfinder .productversions .colcontent .title[title="%(version_name)s"][data-product="%(product_name)s"])')
+    _success_message_locator = (By.CSS_SELECTOR, '#messages .message.success')
 
     def go_to_create_version_page(self):
         self.selenium.get(self.base_url + '/manage/productversion/add/')
@@ -39,6 +41,10 @@ class MozTrapCreateVersionPage(MozTrapBasePage):
         product_select.select_by_visible_text(product_name)
 
         self.selenium.find_element(*self._submit_locator).click()
+
+        WebDriverWait(self.selenium, self.timeout).until(
+            lambda s: self.is_element_present(*self._success_message_locator)
+        )
 
         return version
 


### PR DESCRIPTION
[test_that_user_can_select_run][test_link] is failing intermittently because the product version is not found in the drop-down menu when trying to create a new run.

The test creates a new product using the API to use for the run, after that it creates a new version for that product. When the test fails I noticed that the new version for the product is not created. Here is a link to the Jenkins [test run][run_link].

I could not reproduce the issue locally with manual testing, but the automated tests failed 30% of the time. It looks like the page changes too fast when trying to create the new version so I added a wait for the success message to be present.

[test_link]:https://github.com/mozilla/moztrap-tests/blob/master/tests/test_homepage.py#L70

[run_link]:http://selenium.qa.mtv2.mozilla.com:8080/view/All%20not%20B2G/job/moztrap.dev/647/HTML_Report/