### PR TITLE
Address failure of select_by_visible_text by waiting for text to be present

### DIFF
--- a/pages/create_run_page.py
+++ b/pages/create_run_page.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.select import Select
+from selenium.webdriver.support.ui import WebDriverWait
 
 from pages.base_page import MozTrapBasePage
 from pages.regions.multiselect_widget import MultiselectWidget
@@ -54,7 +55,10 @@ class MozTrapCreateRunPage(MozTrapBasePage):
             if series_run:
                 series_element.click()
 
-        product_version_select = Select(self.selenium.find_element(*self._product_version_select_locator))
+        product_version_select_element = self.selenium.find_element(*self._product_version_select_locator)
+        product_version_select = Select(product_version_select_element)
+        WebDriverWait(self.selenium, self.timeout).until(
+            lambda s: product_version in product_version_select_element.text)
         product_version_select.select_by_visible_text(product_version)
 
         self.selenium.find_element(*self._description_locator).send_keys(run['desc'])


### PR DESCRIPTION
There is a frequent intermittent failure that looks like this [1]:

```
tests/test_homepage.py:58: in test_that_user_can_select_version
>       run = self.create_run(mozwebqa_logged_in, product=product, activate=True)
pages/base_test.py:71: in create_run
>       run = create_run_pg.create_run(product_version=product_version, suite_list=suite_name_list)
pages/create_run_page.py:58: in create_run
>       product_version_select.select_by_visible_text(product_version)
.env/lib/python2.7/site-packages/selenium/webdriver/support/select.py:136: in select_by_visible_text
>           raise NoSuchElementException("Could not locate element with visible text: %s" % text)
E           NoSuchElementException: Message: Could not locate element with visible text: Test Product 2015-03-17T04:47:14.841582 Test Version 2015-03-17T04:47:18.304395
```

I believe that what is happening is that the options for the select are not finished populating before we attempt the `select_by_visible_text`, which is why the expected text is not found. I have addressed this by adding a wait that waits for the expected text to be present in the option list before proceeding.

Initially I did this by creating a new class called `MoztrapSelect` in which I extended `select_by_visible_text` in `Select` to add a wait for the text to be present. We could then use that `MoztrapSelect` class in all cases in which we use `select_by_visible_text` for safety. After doing this I reviewed the failures and noticed that all of them were in the one `create_run` method, so it seemed like overkill to create a new class and replace the use of `Select` with `MoztrapSelect` everywhere, when only one of the uses was an issue.

If we find that we do end up needing this extra wait in other places, then we can revisit that approach, but for now I think it makes sense to just add the one wait here.

[1] https://webqa-ci.mozilla.com/job/moztrap.stage/32/testReport/junit/tests.test_homepage/TestHomepage/test_that_user_can_select_version/