### PR TITLE
Change expected response code for api delete method to 200 from 204

### DIFF
--- a/mocks/moztrap_api.py
+++ b/mocks/moztrap_api.py
@@ -48,7 +48,7 @@ class MoztrapAPI:
             params=self.params,
             headers=self.headers)
         response.raise_for_status()
-        if response.status_code == 204:
+        if response.status_code == 200:
             return True
         else:
             print "Failed to delete resource: %s with %s.\n%s" % (


### PR DESCRIPTION
This addresses, at least partially, issue #158.

My investigation indicates that the status code returned from a `delete` request against the API is now `200`, whereas before it was `204`. This fixes all of the errors that state `AssertionError: Deletion of product Test Product xxx failed`.

@peterbe or @camd can either of you confirm that this is expected, i.e., it is correct that we should be looking for a 200 response rather than a 204 response from a `delete` request now?

This does not address all of the `HTTPError: 400 Client Error: BAD REQUEST` that also showed up in the report [1]. I will need to investigate those separately.

[1] https://webqa-ci.mozilla.com/view/MozTrap/job/moztrap.stage.saucelabs/82/HTML_Report/