### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,6 @@
-# This pulls in all the libraries needed to run Selenium tests
-# on the Mozilla MozTrap project
-
-UnittestZero
-certifi==0.0.8
-chardet==1.0.1
-execnet==1.1
-py==1.4.26
-pytest==2.7.0
+browserid
+pytest==2.7.3
 pytest-mozwebqa
 pytest-variables
-requests==2.4.3
-selenium
--e git+https://github.com/mozilla/bidpom.git@master#egg=browserid
+requests==2.8.1
+UnittestZero


### PR DESCRIPTION
This brings the current requirements up to date and also fixes the fact that we were grabbing `bidpom` from GitHub which was causing us to pick up a newer version than we wanted. Moztrap-tests is not ready for bidpom 2.0 yet.